### PR TITLE
[AETHER-3244] Returning a 404 status if an item we are trying to delete does not exist

### DIFF
--- a/pkg/aether_2_0_0/server/aether-2.0.0-impl.go
+++ b/pkg/aether_2_0_0/server/aether-2.0.0-impl.go
@@ -29,6 +29,13 @@ import (
 func (i *ServerImpl) gnmiDeleteConnectivityServices(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetConnectivityServices(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -102,6 +109,13 @@ func (i *ServerImpl) gnmiPostConnectivityServices(ctx context.Context, body []by
 // gnmiDeleteConnectivityServicesConnectivityService deletes an instance of Connectivity-services_Connectivity-service.
 func (i *ServerImpl) gnmiDeleteConnectivityServicesConnectivityService(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetConnectivityServicesConnectivityService(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -177,6 +191,13 @@ func (i *ServerImpl) gnmiPostConnectivityServicesConnectivityService(ctx context
 func (i *ServerImpl) gnmiDeleteEnterprises(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprises(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -250,6 +271,13 @@ func (i *ServerImpl) gnmiPostEnterprises(ctx context.Context, body []byte,
 // gnmiDeleteEnterprisesEnterprise deletes an instance of Enterprises_Enterprise.
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterprise(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterprise(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -325,6 +353,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterprise(ctx context.Context, body []b
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseApplication(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseApplication(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -398,6 +433,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseApplication(ctx context.Contex
 // gnmiDeleteEnterprisesEnterpriseApplicationEndpoint deletes an instance of Enterprises_Enterprise_Application_Endpoint.
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseApplicationEndpoint(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseApplicationEndpoint(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -473,6 +515,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseApplicationEndpoint(ctx contex
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseApplicationEndpointMbr(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseApplicationEndpointMbr(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -546,6 +595,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseApplicationEndpointMbr(ctx con
 // gnmiDeleteEnterprisesEnterpriseConnectivityService deletes an instance of Enterprises_Enterprise_Connectivity-service.
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseConnectivityService(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseConnectivityService(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -621,6 +677,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseConnectivityService(ctx contex
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSite(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSite(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -694,6 +757,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSite(ctx context.Context, body
 // gnmiDeleteEnterprisesEnterpriseSiteDevice deletes an instance of Enterprises_Enterprise_Site_Device.
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteDevice(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteDevice(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -769,6 +839,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteDevice(ctx context.Context
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteDeviceGroup(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteDeviceGroup(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -842,6 +919,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteDeviceGroup(ctx context.Co
 // gnmiDeleteEnterprisesEnterpriseSiteDeviceGroupDevice deletes an instance of Enterprises_Enterprise_Site_Device-group_Device.
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteDeviceGroupDevice(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteDeviceGroupDevice(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -917,6 +1001,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteDeviceGroupDevice(ctx cont
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteDeviceGroupMbr(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteDeviceGroupMbr(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -990,6 +1081,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteDeviceGroupMbr(ctx context
 // gnmiDeleteEnterprisesEnterpriseSiteImsiDefinition deletes an instance of Enterprises_Enterprise_Site_Imsi-definition.
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteImsiDefinition(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteImsiDefinition(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -1065,6 +1163,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteImsiDefinition(ctx context
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteIpDomain(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteIpDomain(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -1138,6 +1243,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteIpDomain(ctx context.Conte
 // gnmiDeleteEnterprisesEnterpriseSiteMonitoring deletes an instance of Enterprises_Enterprise_Site_Monitoring.
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteMonitoring(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteMonitoring(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -1213,6 +1325,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteMonitoring(ctx context.Con
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteMonitoringEdgeDevice(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteMonitoringEdgeDevice(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -1286,6 +1405,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteMonitoringEdgeDevice(ctx c
 // gnmiDeleteEnterprisesEnterpriseSiteSimCard deletes an instance of Enterprises_Enterprise_Site_Sim-card.
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteSimCard(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteSimCard(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -1361,6 +1487,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteSimCard(ctx context.Contex
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteSlice(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteSlice(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -1434,6 +1567,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteSlice(ctx context.Context,
 // gnmiDeleteEnterprisesEnterpriseSiteSliceDeviceGroup deletes an instance of Enterprises_Enterprise_Site_Slice_Device-group.
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteSliceDeviceGroup(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteSliceDeviceGroup(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -1509,6 +1649,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteSliceDeviceGroup(ctx conte
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteSliceFilter(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteSliceFilter(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -1582,6 +1729,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteSliceFilter(ctx context.Co
 // gnmiDeleteEnterprisesEnterpriseSiteSliceMbr deletes an instance of Enterprises_Enterprise_Site_Slice_Mbr.
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteSliceMbr(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteSliceMbr(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -1657,6 +1811,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteSliceMbr(ctx context.Conte
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteSlicePriorityTrafficRule(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteSlicePriorityTrafficRule(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -1730,6 +1891,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteSlicePriorityTrafficRule(c
 // gnmiDeleteEnterprisesEnterpriseSiteSlicePriorityTrafficRuleGbr deletes an instance of Enterprises_Enterprise_Site_Slice_Priority-traffic-rule_Gbr.
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteSlicePriorityTrafficRuleGbr(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteSlicePriorityTrafficRuleGbr(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -1805,6 +1973,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteSlicePriorityTrafficRuleGb
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteSlicePriorityTrafficRuleMbr(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteSlicePriorityTrafficRuleMbr(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -1878,6 +2053,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteSlicePriorityTrafficRuleMb
 // gnmiDeleteEnterprisesEnterpriseSiteSmallCell deletes an instance of Enterprises_Enterprise_Site_Small-cell.
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteSmallCell(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteSmallCell(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -1953,6 +2135,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteSmallCell(ctx context.Cont
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseSiteUpf(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseSiteUpf(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -2026,6 +2215,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseSiteUpf(ctx context.Context, b
 // gnmiDeleteEnterprisesEnterpriseTemplate deletes an instance of Enterprises_Enterprise_Template.
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseTemplate(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseTemplate(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -2101,6 +2297,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseTemplate(ctx context.Context, 
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseTemplateMbr(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseTemplateMbr(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -2175,6 +2378,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseTemplateMbr(ctx context.Contex
 func (i *ServerImpl) gnmiDeleteEnterprisesEnterpriseTrafficClass(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprisesEnterpriseTrafficClass(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -2248,6 +2458,13 @@ func (i *ServerImpl) gnmiPostEnterprisesEnterpriseTrafficClass(ctx context.Conte
 // gnmiDeleteTarget deletes an instance of target.
 func (i *ServerImpl) gnmiDeleteTarget(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetTarget(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -2433,7 +2650,7 @@ func (i *ServerImpl) DeleteConnectivityServices(ctx echo.Context, target externa
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteConnectivityServices")
@@ -2457,7 +2674,7 @@ func (i *ServerImpl) GetConnectivityServices(ctx echo.Context, target externalRe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetConnectivityServices")
@@ -2490,7 +2707,7 @@ func (i *ServerImpl) PostConnectivityServices(ctx echo.Context, target externalR
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostConnectivityServices")
@@ -2518,7 +2735,7 @@ func (i *ServerImpl) DeleteConnectivityServicesConnectivityService(ctx echo.Cont
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteConnectivityServicesConnectivityService")
@@ -2542,7 +2759,7 @@ func (i *ServerImpl) GetConnectivityServicesConnectivityService(ctx echo.Context
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetConnectivityServicesConnectivityService")
@@ -2575,7 +2792,7 @@ func (i *ServerImpl) PostConnectivityServicesConnectivityService(ctx echo.Contex
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostConnectivityServicesConnectivityService")
@@ -2603,7 +2820,7 @@ func (i *ServerImpl) DeleteEnterprises(ctx echo.Context, target externalRef0.Tar
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprises")
@@ -2627,7 +2844,7 @@ func (i *ServerImpl) GetEnterprises(ctx echo.Context, target externalRef0.Target
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprises")
@@ -2660,7 +2877,7 @@ func (i *ServerImpl) PostEnterprises(ctx echo.Context, target externalRef0.Targe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprises")
@@ -2688,7 +2905,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterprise(ctx echo.Context, target extern
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterprise")
@@ -2712,7 +2929,7 @@ func (i *ServerImpl) GetEnterprisesEnterprise(ctx echo.Context, target externalR
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterprise")
@@ -2745,7 +2962,7 @@ func (i *ServerImpl) PostEnterprisesEnterprise(ctx echo.Context, target external
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterprise")
@@ -2773,7 +2990,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseApplication(ctx echo.Context, ta
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseApplication")
@@ -2797,7 +3014,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseApplication(ctx echo.Context, targe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseApplication")
@@ -2830,7 +3047,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseApplication(ctx echo.Context, targ
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseApplication")
@@ -2858,7 +3075,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseApplicationEndpoint(ctx echo.Con
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseApplicationEndpoint")
@@ -2882,7 +3099,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseApplicationEndpoint(ctx echo.Contex
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseApplicationEndpoint")
@@ -2915,7 +3132,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseApplicationEndpoint(ctx echo.Conte
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseApplicationEndpoint")
@@ -2943,7 +3160,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseApplicationEndpointMbr(ctx echo.
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseApplicationEndpointMbr")
@@ -2967,7 +3184,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseApplicationEndpointMbr(ctx echo.Con
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseApplicationEndpointMbr")
@@ -3000,7 +3217,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseApplicationEndpointMbr(ctx echo.Co
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseApplicationEndpointMbr")
@@ -3028,7 +3245,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseConnectivityService(ctx echo.Con
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseConnectivityService")
@@ -3052,7 +3269,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseConnectivityService(ctx echo.Contex
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseConnectivityService")
@@ -3085,7 +3302,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseConnectivityService(ctx echo.Conte
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseConnectivityService")
@@ -3113,7 +3330,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSite(ctx echo.Context, target ex
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSite")
@@ -3137,7 +3354,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSite(ctx echo.Context, target exter
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSite")
@@ -3170,7 +3387,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSite(ctx echo.Context, target exte
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSite")
@@ -3198,7 +3415,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSiteDeviceGroup(ctx echo.Context
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSiteDeviceGroup")
@@ -3222,7 +3439,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSiteDeviceGroup(ctx echo.Context, t
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSiteDeviceGroup")
@@ -3255,7 +3472,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSiteDeviceGroup(ctx echo.Context, 
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSiteDeviceGroup")
@@ -3283,7 +3500,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSiteDeviceGroupDevice(ctx echo.C
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSiteDeviceGroupDevice")
@@ -3307,7 +3524,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSiteDeviceGroupDevice(ctx echo.Cont
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSiteDeviceGroupDevice")
@@ -3340,7 +3557,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSiteDeviceGroupDevice(ctx echo.Con
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSiteDeviceGroupDevice")
@@ -3368,7 +3585,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSiteDeviceGroupMbr(ctx echo.Cont
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSiteDeviceGroupMbr")
@@ -3392,7 +3609,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSiteDeviceGroupMbr(ctx echo.Context
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSiteDeviceGroupMbr")
@@ -3425,7 +3642,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSiteDeviceGroupMbr(ctx echo.Contex
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSiteDeviceGroupMbr")
@@ -3453,7 +3670,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSiteDevice(ctx echo.Context, tar
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSiteDevice")
@@ -3477,7 +3694,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSiteDevice(ctx echo.Context, target
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSiteDevice")
@@ -3510,7 +3727,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSiteDevice(ctx echo.Context, targe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSiteDevice")
@@ -3538,7 +3755,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSiteImsiDefinition(ctx echo.Cont
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSiteImsiDefinition")
@@ -3562,7 +3779,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSiteImsiDefinition(ctx echo.Context
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSiteImsiDefinition")
@@ -3595,7 +3812,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSiteImsiDefinition(ctx echo.Contex
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSiteImsiDefinition")
@@ -3623,7 +3840,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSiteIpDomain(ctx echo.Context, t
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSiteIpDomain")
@@ -3647,7 +3864,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSiteIpDomain(ctx echo.Context, targ
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSiteIpDomain")
@@ -3680,7 +3897,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSiteIpDomain(ctx echo.Context, tar
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSiteIpDomain")
@@ -3708,7 +3925,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSiteMonitoring(ctx echo.Context,
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSiteMonitoring")
@@ -3732,7 +3949,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSiteMonitoring(ctx echo.Context, ta
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSiteMonitoring")
@@ -3765,7 +3982,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSiteMonitoring(ctx echo.Context, t
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSiteMonitoring")
@@ -3793,7 +4010,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSiteMonitoringEdgeDevice(ctx ech
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSiteMonitoringEdgeDevice")
@@ -3817,7 +4034,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSiteMonitoringEdgeDevice(ctx echo.C
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSiteMonitoringEdgeDevice")
@@ -3850,7 +4067,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSiteMonitoringEdgeDevice(ctx echo.
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSiteMonitoringEdgeDevice")
@@ -3878,7 +4095,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSiteSimCard(ctx echo.Context, ta
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSiteSimCard")
@@ -3902,7 +4119,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSiteSimCard(ctx echo.Context, targe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSiteSimCard")
@@ -3935,7 +4152,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSiteSimCard(ctx echo.Context, targ
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSiteSimCard")
@@ -3963,7 +4180,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSiteSlice(ctx echo.Context, targ
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSiteSlice")
@@ -3987,7 +4204,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSiteSlice(ctx echo.Context, target 
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSiteSlice")
@@ -4020,7 +4237,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSiteSlice(ctx echo.Context, target
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSiteSlice")
@@ -4048,7 +4265,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSiteSliceDeviceGroup(ctx echo.Co
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSiteSliceDeviceGroup")
@@ -4072,7 +4289,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSiteSliceDeviceGroup(ctx echo.Conte
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSiteSliceDeviceGroup")
@@ -4105,7 +4322,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSiteSliceDeviceGroup(ctx echo.Cont
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSiteSliceDeviceGroup")
@@ -4133,7 +4350,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSiteSliceFilter(ctx echo.Context
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSiteSliceFilter")
@@ -4157,7 +4374,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSiteSliceFilter(ctx echo.Context, t
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSiteSliceFilter")
@@ -4190,7 +4407,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSiteSliceFilter(ctx echo.Context, 
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSiteSliceFilter")
@@ -4218,7 +4435,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSiteSliceMbr(ctx echo.Context, t
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSiteSliceMbr")
@@ -4242,7 +4459,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSiteSliceMbr(ctx echo.Context, targ
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSiteSliceMbr")
@@ -4275,7 +4492,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSiteSliceMbr(ctx echo.Context, tar
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSiteSliceMbr")
@@ -4303,7 +4520,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSiteSlicePriorityTrafficRule(ctx
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSiteSlicePriorityTrafficRule")
@@ -4327,7 +4544,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSiteSlicePriorityTrafficRule(ctx ec
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSiteSlicePriorityTrafficRule")
@@ -4360,7 +4577,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSiteSlicePriorityTrafficRule(ctx e
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSiteSlicePriorityTrafficRule")
@@ -4388,7 +4605,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSiteSmallCell(ctx echo.Context, 
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSiteSmallCell")
@@ -4412,7 +4629,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSiteSmallCell(ctx echo.Context, tar
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSiteSmallCell")
@@ -4445,7 +4662,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSiteSmallCell(ctx echo.Context, ta
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSiteSmallCell")
@@ -4473,7 +4690,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseSiteUpf(ctx echo.Context, target
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseSiteUpf")
@@ -4497,7 +4714,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseSiteUpf(ctx echo.Context, target ex
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseSiteUpf")
@@ -4530,7 +4747,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseSiteUpf(ctx echo.Context, target e
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseSiteUpf")
@@ -4558,7 +4775,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseTemplate(ctx echo.Context, targe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseTemplate")
@@ -4582,7 +4799,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseTemplate(ctx echo.Context, target e
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseTemplate")
@@ -4615,7 +4832,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseTemplate(ctx echo.Context, target 
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseTemplate")
@@ -4643,7 +4860,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseTemplateMbr(ctx echo.Context, ta
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseTemplateMbr")
@@ -4667,7 +4884,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseTemplateMbr(ctx echo.Context, targe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseTemplateMbr")
@@ -4700,7 +4917,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseTemplateMbr(ctx echo.Context, targ
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseTemplateMbr")
@@ -4728,7 +4945,7 @@ func (i *ServerImpl) DeleteEnterprisesEnterpriseTrafficClass(ctx echo.Context, t
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprisesEnterpriseTrafficClass")
@@ -4752,7 +4969,7 @@ func (i *ServerImpl) GetEnterprisesEnterpriseTrafficClass(ctx echo.Context, targ
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprisesEnterpriseTrafficClass")
@@ -4785,7 +5002,7 @@ func (i *ServerImpl) PostEnterprisesEnterpriseTrafficClass(ctx echo.Context, tar
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprisesEnterpriseTrafficClass")

--- a/pkg/aether_4_0_0/server/aether-4.0.0-impl.go
+++ b/pkg/aether_4_0_0/server/aether-4.0.0-impl.go
@@ -29,6 +29,13 @@ import (
 func (i *ServerImpl) gnmiDeleteApplication(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetApplication(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -102,6 +109,13 @@ func (i *ServerImpl) gnmiPostApplication(ctx context.Context, body []byte,
 // gnmiDeleteApplicationApplication deletes an instance of Application_Application.
 func (i *ServerImpl) gnmiDeleteApplicationApplication(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetApplicationApplication(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -177,6 +191,13 @@ func (i *ServerImpl) gnmiPostApplicationApplication(ctx context.Context, body []
 func (i *ServerImpl) gnmiDeleteApplicationApplicationEndpoint(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetApplicationApplicationEndpoint(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -250,6 +271,13 @@ func (i *ServerImpl) gnmiPostApplicationApplicationEndpoint(ctx context.Context,
 // gnmiDeleteApplicationApplicationEndpointMbr deletes an instance of Application_Application_Endpoint_Mbr.
 func (i *ServerImpl) gnmiDeleteApplicationApplicationEndpointMbr(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetApplicationApplicationEndpointMbr(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -325,6 +353,13 @@ func (i *ServerImpl) gnmiPostApplicationApplicationEndpointMbr(ctx context.Conte
 func (i *ServerImpl) gnmiDeleteConnectivityService(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetConnectivityService(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -398,6 +433,13 @@ func (i *ServerImpl) gnmiPostConnectivityService(ctx context.Context, body []byt
 // gnmiDeleteConnectivityServiceConnectivityService deletes an instance of Connectivity-service_Connectivity-service.
 func (i *ServerImpl) gnmiDeleteConnectivityServiceConnectivityService(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetConnectivityServiceConnectivityService(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -473,6 +515,13 @@ func (i *ServerImpl) gnmiPostConnectivityServiceConnectivityService(ctx context.
 func (i *ServerImpl) gnmiDeleteDeviceGroup(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetDeviceGroup(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -546,6 +595,13 @@ func (i *ServerImpl) gnmiPostDeviceGroup(ctx context.Context, body []byte,
 // gnmiDeleteDeviceGroupDeviceGroup deletes an instance of Device-group_Device-group.
 func (i *ServerImpl) gnmiDeleteDeviceGroupDeviceGroup(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetDeviceGroupDeviceGroup(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -621,6 +677,13 @@ func (i *ServerImpl) gnmiPostDeviceGroupDeviceGroup(ctx context.Context, body []
 func (i *ServerImpl) gnmiDeleteDeviceGroupDeviceGroupDevice(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetDeviceGroupDeviceGroupDevice(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -694,6 +757,13 @@ func (i *ServerImpl) gnmiPostDeviceGroupDeviceGroupDevice(ctx context.Context, b
 // gnmiDeleteDeviceGroupDeviceGroupDeviceMbr deletes an instance of Device-group_Device-group_Device_Mbr.
 func (i *ServerImpl) gnmiDeleteDeviceGroupDeviceGroupDeviceMbr(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetDeviceGroupDeviceGroupDeviceMbr(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -769,6 +839,13 @@ func (i *ServerImpl) gnmiPostDeviceGroupDeviceGroupDeviceMbr(ctx context.Context
 func (i *ServerImpl) gnmiDeleteDeviceGroupDeviceGroupImsis(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetDeviceGroupDeviceGroupImsis(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -842,6 +919,13 @@ func (i *ServerImpl) gnmiPostDeviceGroupDeviceGroupImsis(ctx context.Context, bo
 // gnmiDeleteEnterprise deletes an instance of Enterprise.
 func (i *ServerImpl) gnmiDeleteEnterprise(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterprise(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -917,6 +1001,13 @@ func (i *ServerImpl) gnmiPostEnterprise(ctx context.Context, body []byte,
 func (i *ServerImpl) gnmiDeleteEnterpriseEnterprise(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterpriseEnterprise(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -990,6 +1081,13 @@ func (i *ServerImpl) gnmiPostEnterpriseEnterprise(ctx context.Context, body []by
 // gnmiDeleteEnterpriseEnterpriseConnectivityService deletes an instance of Enterprise_Enterprise_Connectivity-service.
 func (i *ServerImpl) gnmiDeleteEnterpriseEnterpriseConnectivityService(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetEnterpriseEnterpriseConnectivityService(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -1065,6 +1163,13 @@ func (i *ServerImpl) gnmiPostEnterpriseEnterpriseConnectivityService(ctx context
 func (i *ServerImpl) gnmiDeleteIpDomain(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetIpDomain(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -1138,6 +1243,13 @@ func (i *ServerImpl) gnmiPostIpDomain(ctx context.Context, body []byte,
 // gnmiDeleteIpDomainIpDomain deletes an instance of Ip-domain_Ip-domain.
 func (i *ServerImpl) gnmiDeleteIpDomainIpDomain(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetIpDomainIpDomain(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -1213,6 +1325,13 @@ func (i *ServerImpl) gnmiPostIpDomainIpDomain(ctx context.Context, body []byte,
 func (i *ServerImpl) gnmiDeleteSite(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetSite(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -1286,6 +1405,13 @@ func (i *ServerImpl) gnmiPostSite(ctx context.Context, body []byte,
 // gnmiDeleteSiteSite deletes an instance of Site_Site.
 func (i *ServerImpl) gnmiDeleteSiteSite(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetSiteSite(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -1361,6 +1487,13 @@ func (i *ServerImpl) gnmiPostSiteSite(ctx context.Context, body []byte,
 func (i *ServerImpl) gnmiDeleteSiteSiteImsiDefinition(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetSiteSiteImsiDefinition(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -1434,6 +1567,13 @@ func (i *ServerImpl) gnmiPostSiteSiteImsiDefinition(ctx context.Context, body []
 // gnmiDeleteSiteSiteMonitoring deletes an instance of Site_Site_Monitoring.
 func (i *ServerImpl) gnmiDeleteSiteSiteMonitoring(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetSiteSiteMonitoring(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -1509,6 +1649,13 @@ func (i *ServerImpl) gnmiPostSiteSiteMonitoring(ctx context.Context, body []byte
 func (i *ServerImpl) gnmiDeleteSiteSiteMonitoringEdgeDevice(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetSiteSiteMonitoringEdgeDevice(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -1582,6 +1729,13 @@ func (i *ServerImpl) gnmiPostSiteSiteMonitoringEdgeDevice(ctx context.Context, b
 // gnmiDeleteSiteSiteSmallCell deletes an instance of Site_Site_Small-cell.
 func (i *ServerImpl) gnmiDeleteSiteSiteSmallCell(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetSiteSiteSmallCell(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -1657,6 +1811,13 @@ func (i *ServerImpl) gnmiPostSiteSiteSmallCell(ctx context.Context, body []byte,
 func (i *ServerImpl) gnmiDeleteTemplate(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetTemplate(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -1730,6 +1891,13 @@ func (i *ServerImpl) gnmiPostTemplate(ctx context.Context, body []byte,
 // gnmiDeleteTemplateTemplate deletes an instance of Template_Template.
 func (i *ServerImpl) gnmiDeleteTemplateTemplate(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetTemplateTemplate(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -1805,6 +1973,13 @@ func (i *ServerImpl) gnmiPostTemplateTemplate(ctx context.Context, body []byte,
 func (i *ServerImpl) gnmiDeleteTemplateTemplateSlice(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetTemplateTemplateSlice(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -1878,6 +2053,13 @@ func (i *ServerImpl) gnmiPostTemplateTemplateSlice(ctx context.Context, body []b
 // gnmiDeleteTemplateTemplateSliceMbr deletes an instance of Template_Template_Slice_Mbr.
 func (i *ServerImpl) gnmiDeleteTemplateTemplateSliceMbr(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetTemplateTemplateSliceMbr(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -1953,6 +2135,13 @@ func (i *ServerImpl) gnmiPostTemplateTemplateSliceMbr(ctx context.Context, body 
 func (i *ServerImpl) gnmiDeleteTrafficClass(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetTrafficClass(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -2026,6 +2215,13 @@ func (i *ServerImpl) gnmiPostTrafficClass(ctx context.Context, body []byte,
 // gnmiDeleteTrafficClassTrafficClass deletes an instance of Traffic-class_Traffic-class.
 func (i *ServerImpl) gnmiDeleteTrafficClassTrafficClass(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetTrafficClassTrafficClass(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -2101,6 +2297,13 @@ func (i *ServerImpl) gnmiPostTrafficClassTrafficClass(ctx context.Context, body 
 func (i *ServerImpl) gnmiDeleteUpf(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetUpf(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -2174,6 +2377,13 @@ func (i *ServerImpl) gnmiPostUpf(ctx context.Context, body []byte,
 // gnmiDeleteUpfUpf deletes an instance of Upf_Upf.
 func (i *ServerImpl) gnmiDeleteUpfUpf(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetUpfUpf(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -2249,6 +2459,13 @@ func (i *ServerImpl) gnmiPostUpfUpf(ctx context.Context, body []byte,
 func (i *ServerImpl) gnmiDeleteVcs(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetVcs(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -2322,6 +2539,13 @@ func (i *ServerImpl) gnmiPostVcs(ctx context.Context, body []byte,
 // gnmiDeleteVcsVcs deletes an instance of Vcs_Vcs.
 func (i *ServerImpl) gnmiDeleteVcsVcs(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetVcsVcs(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -2397,6 +2621,13 @@ func (i *ServerImpl) gnmiPostVcsVcs(ctx context.Context, body []byte,
 func (i *ServerImpl) gnmiDeleteVcsVcsDeviceGroup(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetVcsVcsDeviceGroup(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -2470,6 +2701,13 @@ func (i *ServerImpl) gnmiPostVcsVcsDeviceGroup(ctx context.Context, body []byte,
 // gnmiDeleteVcsVcsFilter deletes an instance of Vcs_Vcs_Filter.
 func (i *ServerImpl) gnmiDeleteVcsVcsFilter(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetVcsVcsFilter(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -2545,6 +2783,13 @@ func (i *ServerImpl) gnmiPostVcsVcsFilter(ctx context.Context, body []byte,
 func (i *ServerImpl) gnmiDeleteVcsVcsSlice(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetVcsVcsSlice(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -2619,6 +2864,13 @@ func (i *ServerImpl) gnmiPostVcsVcsSlice(ctx context.Context, body []byte,
 func (i *ServerImpl) gnmiDeleteVcsVcsSliceMbr(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetVcsVcsSliceMbr(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
+
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
 		return nil, err
@@ -2692,6 +2944,13 @@ func (i *ServerImpl) gnmiPostVcsVcsSliceMbr(ctx context.Context, body []byte,
 // gnmiDeleteTarget deletes an instance of target.
 func (i *ServerImpl) gnmiDeleteTarget(ctx context.Context,
 	openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
+
+	// check to see if the item exists before deleting it
+	response, err := i.gnmiGetTarget(ctx, openApiPath, target, args...)
+	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+	}
 
 	gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
 	if err != nil {
@@ -2899,7 +3158,7 @@ func (i *ServerImpl) DeleteApplication(ctx echo.Context, target externalRef0.Tar
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteApplication")
@@ -2923,7 +3182,7 @@ func (i *ServerImpl) GetApplication(ctx echo.Context, target externalRef0.Target
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetApplication")
@@ -2956,7 +3215,7 @@ func (i *ServerImpl) PostApplication(ctx echo.Context, target externalRef0.Targe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostApplication")
@@ -2984,7 +3243,7 @@ func (i *ServerImpl) DeleteApplicationApplication(ctx echo.Context, target exter
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteApplicationApplication")
@@ -3008,7 +3267,7 @@ func (i *ServerImpl) GetApplicationApplication(ctx echo.Context, target external
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetApplicationApplication")
@@ -3041,7 +3300,7 @@ func (i *ServerImpl) PostApplicationApplication(ctx echo.Context, target externa
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostApplicationApplication")
@@ -3069,7 +3328,7 @@ func (i *ServerImpl) DeleteApplicationApplicationEndpoint(ctx echo.Context, targ
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteApplicationApplicationEndpoint")
@@ -3093,7 +3352,7 @@ func (i *ServerImpl) GetApplicationApplicationEndpoint(ctx echo.Context, target 
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetApplicationApplicationEndpoint")
@@ -3126,7 +3385,7 @@ func (i *ServerImpl) PostApplicationApplicationEndpoint(ctx echo.Context, target
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostApplicationApplicationEndpoint")
@@ -3154,7 +3413,7 @@ func (i *ServerImpl) DeleteApplicationApplicationEndpointMbr(ctx echo.Context, t
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteApplicationApplicationEndpointMbr")
@@ -3178,7 +3437,7 @@ func (i *ServerImpl) GetApplicationApplicationEndpointMbr(ctx echo.Context, targ
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetApplicationApplicationEndpointMbr")
@@ -3211,7 +3470,7 @@ func (i *ServerImpl) PostApplicationApplicationEndpointMbr(ctx echo.Context, tar
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostApplicationApplicationEndpointMbr")
@@ -3239,7 +3498,7 @@ func (i *ServerImpl) DeleteConnectivityService(ctx echo.Context, target external
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteConnectivityService")
@@ -3263,7 +3522,7 @@ func (i *ServerImpl) GetConnectivityService(ctx echo.Context, target externalRef
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetConnectivityService")
@@ -3296,7 +3555,7 @@ func (i *ServerImpl) PostConnectivityService(ctx echo.Context, target externalRe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostConnectivityService")
@@ -3324,7 +3583,7 @@ func (i *ServerImpl) DeleteConnectivityServiceConnectivityService(ctx echo.Conte
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteConnectivityServiceConnectivityService")
@@ -3348,7 +3607,7 @@ func (i *ServerImpl) GetConnectivityServiceConnectivityService(ctx echo.Context,
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetConnectivityServiceConnectivityService")
@@ -3381,7 +3640,7 @@ func (i *ServerImpl) PostConnectivityServiceConnectivityService(ctx echo.Context
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostConnectivityServiceConnectivityService")
@@ -3409,7 +3668,7 @@ func (i *ServerImpl) DeleteDeviceGroup(ctx echo.Context, target externalRef0.Tar
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteDeviceGroup")
@@ -3433,7 +3692,7 @@ func (i *ServerImpl) GetDeviceGroup(ctx echo.Context, target externalRef0.Target
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetDeviceGroup")
@@ -3466,7 +3725,7 @@ func (i *ServerImpl) PostDeviceGroup(ctx echo.Context, target externalRef0.Targe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostDeviceGroup")
@@ -3494,7 +3753,7 @@ func (i *ServerImpl) DeleteDeviceGroupDeviceGroup(ctx echo.Context, target exter
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteDeviceGroupDeviceGroup")
@@ -3518,7 +3777,7 @@ func (i *ServerImpl) GetDeviceGroupDeviceGroup(ctx echo.Context, target external
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetDeviceGroupDeviceGroup")
@@ -3551,7 +3810,7 @@ func (i *ServerImpl) PostDeviceGroupDeviceGroup(ctx echo.Context, target externa
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostDeviceGroupDeviceGroup")
@@ -3579,7 +3838,7 @@ func (i *ServerImpl) DeleteDeviceGroupDeviceGroupDevice(ctx echo.Context, target
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteDeviceGroupDeviceGroupDevice")
@@ -3603,7 +3862,7 @@ func (i *ServerImpl) GetDeviceGroupDeviceGroupDevice(ctx echo.Context, target ex
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetDeviceGroupDeviceGroupDevice")
@@ -3636,7 +3895,7 @@ func (i *ServerImpl) PostDeviceGroupDeviceGroupDevice(ctx echo.Context, target e
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostDeviceGroupDeviceGroupDevice")
@@ -3664,7 +3923,7 @@ func (i *ServerImpl) DeleteDeviceGroupDeviceGroupDeviceMbr(ctx echo.Context, tar
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteDeviceGroupDeviceGroupDeviceMbr")
@@ -3688,7 +3947,7 @@ func (i *ServerImpl) GetDeviceGroupDeviceGroupDeviceMbr(ctx echo.Context, target
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetDeviceGroupDeviceGroupDeviceMbr")
@@ -3721,7 +3980,7 @@ func (i *ServerImpl) PostDeviceGroupDeviceGroupDeviceMbr(ctx echo.Context, targe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostDeviceGroupDeviceGroupDeviceMbr")
@@ -3749,7 +4008,7 @@ func (i *ServerImpl) DeleteDeviceGroupDeviceGroupImsis(ctx echo.Context, target 
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteDeviceGroupDeviceGroupImsis")
@@ -3773,7 +4032,7 @@ func (i *ServerImpl) GetDeviceGroupDeviceGroupImsis(ctx echo.Context, target ext
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetDeviceGroupDeviceGroupImsis")
@@ -3806,7 +4065,7 @@ func (i *ServerImpl) PostDeviceGroupDeviceGroupImsis(ctx echo.Context, target ex
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostDeviceGroupDeviceGroupImsis")
@@ -3834,7 +4093,7 @@ func (i *ServerImpl) DeleteEnterprise(ctx echo.Context, target externalRef0.Targ
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterprise")
@@ -3858,7 +4117,7 @@ func (i *ServerImpl) GetEnterprise(ctx echo.Context, target externalRef0.Target)
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterprise")
@@ -3891,7 +4150,7 @@ func (i *ServerImpl) PostEnterprise(ctx echo.Context, target externalRef0.Target
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterprise")
@@ -3919,7 +4178,7 @@ func (i *ServerImpl) DeleteEnterpriseEnterprise(ctx echo.Context, target externa
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterpriseEnterprise")
@@ -3943,7 +4202,7 @@ func (i *ServerImpl) GetEnterpriseEnterprise(ctx echo.Context, target externalRe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterpriseEnterprise")
@@ -3976,7 +4235,7 @@ func (i *ServerImpl) PostEnterpriseEnterprise(ctx echo.Context, target externalR
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterpriseEnterprise")
@@ -4004,7 +4263,7 @@ func (i *ServerImpl) DeleteEnterpriseEnterpriseConnectivityService(ctx echo.Cont
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteEnterpriseEnterpriseConnectivityService")
@@ -4028,7 +4287,7 @@ func (i *ServerImpl) GetEnterpriseEnterpriseConnectivityService(ctx echo.Context
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetEnterpriseEnterpriseConnectivityService")
@@ -4061,7 +4320,7 @@ func (i *ServerImpl) PostEnterpriseEnterpriseConnectivityService(ctx echo.Contex
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostEnterpriseEnterpriseConnectivityService")
@@ -4089,7 +4348,7 @@ func (i *ServerImpl) DeleteIpDomain(ctx echo.Context, target externalRef0.Target
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteIpDomain")
@@ -4113,7 +4372,7 @@ func (i *ServerImpl) GetIpDomain(ctx echo.Context, target externalRef0.Target) e
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetIpDomain")
@@ -4146,7 +4405,7 @@ func (i *ServerImpl) PostIpDomain(ctx echo.Context, target externalRef0.Target) 
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostIpDomain")
@@ -4174,7 +4433,7 @@ func (i *ServerImpl) DeleteIpDomainIpDomain(ctx echo.Context, target externalRef
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteIpDomainIpDomain")
@@ -4198,7 +4457,7 @@ func (i *ServerImpl) GetIpDomainIpDomain(ctx echo.Context, target externalRef0.T
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetIpDomainIpDomain")
@@ -4231,7 +4490,7 @@ func (i *ServerImpl) PostIpDomainIpDomain(ctx echo.Context, target externalRef0.
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostIpDomainIpDomain")
@@ -4259,7 +4518,7 @@ func (i *ServerImpl) DeleteSite(ctx echo.Context, target externalRef0.Target) er
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteSite")
@@ -4283,7 +4542,7 @@ func (i *ServerImpl) GetSite(ctx echo.Context, target externalRef0.Target) error
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetSite")
@@ -4316,7 +4575,7 @@ func (i *ServerImpl) PostSite(ctx echo.Context, target externalRef0.Target) erro
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostSite")
@@ -4344,7 +4603,7 @@ func (i *ServerImpl) DeleteSiteSite(ctx echo.Context, target externalRef0.Target
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteSiteSite")
@@ -4368,7 +4627,7 @@ func (i *ServerImpl) GetSiteSite(ctx echo.Context, target externalRef0.Target, i
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetSiteSite")
@@ -4401,7 +4660,7 @@ func (i *ServerImpl) PostSiteSite(ctx echo.Context, target externalRef0.Target, 
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostSiteSite")
@@ -4429,7 +4688,7 @@ func (i *ServerImpl) DeleteSiteSiteImsiDefinition(ctx echo.Context, target exter
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteSiteSiteImsiDefinition")
@@ -4453,7 +4712,7 @@ func (i *ServerImpl) GetSiteSiteImsiDefinition(ctx echo.Context, target external
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetSiteSiteImsiDefinition")
@@ -4486,7 +4745,7 @@ func (i *ServerImpl) PostSiteSiteImsiDefinition(ctx echo.Context, target externa
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostSiteSiteImsiDefinition")
@@ -4514,7 +4773,7 @@ func (i *ServerImpl) DeleteSiteSiteMonitoring(ctx echo.Context, target externalR
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteSiteSiteMonitoring")
@@ -4538,7 +4797,7 @@ func (i *ServerImpl) GetSiteSiteMonitoring(ctx echo.Context, target externalRef0
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetSiteSiteMonitoring")
@@ -4571,7 +4830,7 @@ func (i *ServerImpl) PostSiteSiteMonitoring(ctx echo.Context, target externalRef
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostSiteSiteMonitoring")
@@ -4599,7 +4858,7 @@ func (i *ServerImpl) DeleteSiteSiteMonitoringEdgeDevice(ctx echo.Context, target
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteSiteSiteMonitoringEdgeDevice")
@@ -4623,7 +4882,7 @@ func (i *ServerImpl) GetSiteSiteMonitoringEdgeDevice(ctx echo.Context, target ex
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetSiteSiteMonitoringEdgeDevice")
@@ -4656,7 +4915,7 @@ func (i *ServerImpl) PostSiteSiteMonitoringEdgeDevice(ctx echo.Context, target e
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostSiteSiteMonitoringEdgeDevice")
@@ -4684,7 +4943,7 @@ func (i *ServerImpl) DeleteSiteSiteSmallCell(ctx echo.Context, target externalRe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteSiteSiteSmallCell")
@@ -4708,7 +4967,7 @@ func (i *ServerImpl) GetSiteSiteSmallCell(ctx echo.Context, target externalRef0.
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetSiteSiteSmallCell")
@@ -4741,7 +5000,7 @@ func (i *ServerImpl) PostSiteSiteSmallCell(ctx echo.Context, target externalRef0
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostSiteSiteSmallCell")
@@ -4769,7 +5028,7 @@ func (i *ServerImpl) DeleteTemplate(ctx echo.Context, target externalRef0.Target
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteTemplate")
@@ -4793,7 +5052,7 @@ func (i *ServerImpl) GetTemplate(ctx echo.Context, target externalRef0.Target) e
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetTemplate")
@@ -4826,7 +5085,7 @@ func (i *ServerImpl) PostTemplate(ctx echo.Context, target externalRef0.Target) 
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostTemplate")
@@ -4854,7 +5113,7 @@ func (i *ServerImpl) DeleteTemplateTemplate(ctx echo.Context, target externalRef
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteTemplateTemplate")
@@ -4878,7 +5137,7 @@ func (i *ServerImpl) GetTemplateTemplate(ctx echo.Context, target externalRef0.T
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetTemplateTemplate")
@@ -4911,7 +5170,7 @@ func (i *ServerImpl) PostTemplateTemplate(ctx echo.Context, target externalRef0.
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostTemplateTemplate")
@@ -4939,7 +5198,7 @@ func (i *ServerImpl) DeleteTemplateTemplateSlice(ctx echo.Context, target extern
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteTemplateTemplateSlice")
@@ -4963,7 +5222,7 @@ func (i *ServerImpl) GetTemplateTemplateSlice(ctx echo.Context, target externalR
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetTemplateTemplateSlice")
@@ -4996,7 +5255,7 @@ func (i *ServerImpl) PostTemplateTemplateSlice(ctx echo.Context, target external
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostTemplateTemplateSlice")
@@ -5024,7 +5283,7 @@ func (i *ServerImpl) DeleteTemplateTemplateSliceMbr(ctx echo.Context, target ext
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteTemplateTemplateSliceMbr")
@@ -5048,7 +5307,7 @@ func (i *ServerImpl) GetTemplateTemplateSliceMbr(ctx echo.Context, target extern
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetTemplateTemplateSliceMbr")
@@ -5081,7 +5340,7 @@ func (i *ServerImpl) PostTemplateTemplateSliceMbr(ctx echo.Context, target exter
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostTemplateTemplateSliceMbr")
@@ -5109,7 +5368,7 @@ func (i *ServerImpl) DeleteTrafficClass(ctx echo.Context, target externalRef0.Ta
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteTrafficClass")
@@ -5133,7 +5392,7 @@ func (i *ServerImpl) GetTrafficClass(ctx echo.Context, target externalRef0.Targe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetTrafficClass")
@@ -5166,7 +5425,7 @@ func (i *ServerImpl) PostTrafficClass(ctx echo.Context, target externalRef0.Targ
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostTrafficClass")
@@ -5194,7 +5453,7 @@ func (i *ServerImpl) DeleteTrafficClassTrafficClass(ctx echo.Context, target ext
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteTrafficClassTrafficClass")
@@ -5218,7 +5477,7 @@ func (i *ServerImpl) GetTrafficClassTrafficClass(ctx echo.Context, target extern
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetTrafficClassTrafficClass")
@@ -5251,7 +5510,7 @@ func (i *ServerImpl) PostTrafficClassTrafficClass(ctx echo.Context, target exter
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostTrafficClassTrafficClass")
@@ -5279,7 +5538,7 @@ func (i *ServerImpl) DeleteUpf(ctx echo.Context, target externalRef0.Target) err
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteUpf")
@@ -5303,7 +5562,7 @@ func (i *ServerImpl) GetUpf(ctx echo.Context, target externalRef0.Target) error 
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetUpf")
@@ -5336,7 +5595,7 @@ func (i *ServerImpl) PostUpf(ctx echo.Context, target externalRef0.Target) error
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostUpf")
@@ -5364,7 +5623,7 @@ func (i *ServerImpl) DeleteUpfUpf(ctx echo.Context, target externalRef0.Target, 
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteUpfUpf")
@@ -5388,7 +5647,7 @@ func (i *ServerImpl) GetUpfUpf(ctx echo.Context, target externalRef0.Target, id 
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetUpfUpf")
@@ -5421,7 +5680,7 @@ func (i *ServerImpl) PostUpfUpf(ctx echo.Context, target externalRef0.Target, id
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostUpfUpf")
@@ -5449,7 +5708,7 @@ func (i *ServerImpl) DeleteVcs(ctx echo.Context, target externalRef0.Target) err
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteVcs")
@@ -5473,7 +5732,7 @@ func (i *ServerImpl) GetVcs(ctx echo.Context, target externalRef0.Target) error 
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetVcs")
@@ -5506,7 +5765,7 @@ func (i *ServerImpl) PostVcs(ctx echo.Context, target externalRef0.Target) error
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostVcs")
@@ -5534,7 +5793,7 @@ func (i *ServerImpl) DeleteVcsVcs(ctx echo.Context, target externalRef0.Target, 
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteVcsVcs")
@@ -5558,7 +5817,7 @@ func (i *ServerImpl) GetVcsVcs(ctx echo.Context, target externalRef0.Target, id 
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetVcsVcs")
@@ -5591,7 +5850,7 @@ func (i *ServerImpl) PostVcsVcs(ctx echo.Context, target externalRef0.Target, id
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostVcsVcs")
@@ -5619,7 +5878,7 @@ func (i *ServerImpl) DeleteVcsVcsDeviceGroup(ctx echo.Context, target externalRe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteVcsVcsDeviceGroup")
@@ -5643,7 +5902,7 @@ func (i *ServerImpl) GetVcsVcsDeviceGroup(ctx echo.Context, target externalRef0.
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetVcsVcsDeviceGroup")
@@ -5676,7 +5935,7 @@ func (i *ServerImpl) PostVcsVcsDeviceGroup(ctx echo.Context, target externalRef0
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostVcsVcsDeviceGroup")
@@ -5704,7 +5963,7 @@ func (i *ServerImpl) DeleteVcsVcsFilter(ctx echo.Context, target externalRef0.Ta
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteVcsVcsFilter")
@@ -5728,7 +5987,7 @@ func (i *ServerImpl) GetVcsVcsFilter(ctx echo.Context, target externalRef0.Targe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetVcsVcsFilter")
@@ -5761,7 +6020,7 @@ func (i *ServerImpl) PostVcsVcsFilter(ctx echo.Context, target externalRef0.Targ
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostVcsVcsFilter")
@@ -5789,7 +6048,7 @@ func (i *ServerImpl) DeleteVcsVcsSlice(ctx echo.Context, target externalRef0.Tar
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteVcsVcsSlice")
@@ -5813,7 +6072,7 @@ func (i *ServerImpl) GetVcsVcsSlice(ctx echo.Context, target externalRef0.Target
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetVcsVcsSlice")
@@ -5846,7 +6105,7 @@ func (i *ServerImpl) PostVcsVcsSlice(ctx echo.Context, target externalRef0.Targe
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostVcsVcsSlice")
@@ -5874,7 +6133,7 @@ func (i *ServerImpl) DeleteVcsVcsSliceMbr(ctx echo.Context, target externalRef0.
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("DeleteVcsVcsSliceMbr")
@@ -5898,7 +6157,7 @@ func (i *ServerImpl) GetVcsVcsSliceMbr(ctx echo.Context, target externalRef0.Tar
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("GetVcsVcsSliceMbr")
@@ -5931,7 +6190,7 @@ func (i *ServerImpl) PostVcsVcsSliceMbr(ctx echo.Context, target externalRef0.Ta
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 
 	log.Infof("PostVcsVcsSliceMbr")

--- a/pkg/codegen/templates/typedef.tmpl
+++ b/pkg/codegen/templates/typedef.tmpl
@@ -15,6 +15,13 @@ import 	(
 func (i *ServerImpl) {{printf "gnmiDelete%s" .TypeName}}(ctx context.Context,
     openApiPath string, target externalRef0.Target, args ...string) (*string, error) {
 
+    // check to see if the item exists before deleting it
+    response, err := i.{{printf "gnmiGet%s" .TypeName}}(ctx, openApiPath, target, args...)
+    	if reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil() {
+    		log.Infof("Item at path %s with args %v not found", openApiPath, args)
+    		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("item at path %s with args %v does not exists", openApiPath, args))
+    	}
+
     gnmiSet, err := utils.NewGnmiSetDeleteRequest(openApiPath, string(target), args...)
     if err != nil {
         return nil, err

--- a/pkg/codegen/templates/wrappers.tmpl
+++ b/pkg/codegen/templates/wrappers.tmpl
@@ -43,7 +43,7 @@ func (i *ServerImpl) {{.OperationId}} (ctx echo.Context{{genParamArgs .PathParam
 	}
 	// It's not enough to check if response==nil - see https://medium.com/@glucn/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7
 	if (reflect.ValueOf(response).Kind() == reflect.Ptr && reflect.ValueOf(response).IsNil()) {
-		return echo.NewHTTPError(http.StatusNoContent)
+		return ctx.NoContent(http.StatusNotFound)
 	}
 {{end}}
 

--- a/pkg/utils/rpcerror.go
+++ b/pkg/utils/rpcerror.go
@@ -27,6 +27,13 @@ const (
 
 // ConvertGrpcError - capture gRPC error messages properly
 func ConvertGrpcError(err error) *echo.HTTPError {
+
+	// if the error is already the right type, just return it
+	switch e := err.(type) {
+	case *echo.HTTPError:
+		return e
+	}
+
 	if strings.HasPrefix(err.Error(), respInternalInvalid) {
 		return echo.NewHTTPError(http.StatusNoContent, err.Error())
 	} else if strings.HasPrefix(err.Error(), respInvalidValidation) {

--- a/pkg/utils/rpcerror_test.go
+++ b/pkg/utils/rpcerror_test.go
@@ -7,9 +7,19 @@ package utils
 
 import (
 	"fmt"
+	"github.com/labstack/echo/v4"
 	"gotest.tools/assert"
+	"net/http"
 	"testing"
 )
+
+// if we receive an error that is already an HTTP error
+// simply return that without converting
+func Test_ConvertHttpError(t *testing.T) {
+	err := echo.NewHTTPError(http.StatusBadRequest, "http-test-err")
+	httpError := ConvertGrpcError(err)
+	assert.Error(t, httpError, "code=400, message=http-test-err")
+}
 
 func Test_ConvertGrpcError_NoContent(t *testing.T) {
 	validationErrMsg := respInternalInvalid + ` test1`


### PR DESCRIPTION
In `gNMI` this is a valid operation, but it is not in `REST`.
This will return an acceptable REST status code (`404`) if we try to delete a non-existing item.

To try you can issue this command:
```
curl -X DELETE -v http://localhost:8181/aether/v2.0.0/connectivity-service-v2/enterprises/enterprise/non-existing
```
with and without the patch