### PR TITLE
[AETHER-3249] Do not allow undefined enterprise or site ids in a gNMI request

### DIFF
--- a/pkg/toplevel/server/toplevel-gnmi.go
+++ b/pkg/toplevel/server/toplevel-gnmi.go
@@ -30,7 +30,7 @@ func (i *ServerImpl) gnmiPatchAetherRocAPI(ctx context.Context, body []byte, dum
 
 	patchBody, err := encodeToGnmiPatchBody(&jsonObj)
 	if err != nil {
-		return nil, fmt.Errorf("unable to convert types.PatchBody to gNMI %v", err)
+		return nil, err
 	}
 	gnmiSet, err := utils.NewGnmiSetRequest(patchBody.Updates, patchBody.Deletes,
 		patchBody.Ext100Name, patchBody.Ext101Version, patchBody.Ext102Type, patchBody.Ext111Strategy)

--- a/pkg/toplevel/server/toplevel-gnmi_test.go
+++ b/pkg/toplevel/server/toplevel-gnmi_test.go
@@ -31,5 +31,5 @@ func TestGnmiPachAetherRocApi_wrongFormat2(t *testing.T) {
 
 	body := []byte(`{"Updates":{}}`)
 	_, err := server.gnmiPatchAetherRocAPI(context.Background(), body, "")
-	assert.Error(t, err, `unable to convert types.PatchBody to gNMI default-target cannot be blank`)
+	assert.Error(t, err, `default-target cannot be blank`)
 }


### PR DESCRIPTION
Trying to send this request:
```
curl -v -X PATCH -H 'Content-Type: application/json'  http://localhost:8181/aether-roc-api -d '{"default-target":"connectivity-service-v2","Updates":{"Enterprises-2.0.0":{"enterprise":[{"enterprise-id":"undefined","site":[{"site-id":"undefined","sim-card":[{"sim-id":"sim-id","display-name":"display-name","imsi":456,"description":"descirption"}]}]}]}},"Deletes":{"Enterprises-2.0.0":{"enterprise":[{"enterprise-id":"undefined","site":[{"site-id":"undefined","sim-card":[{"sim-id":"sim-id","iccid":"null"}]}]}]}},"Extensions":{"model-version-101":"2.0.0","model-type-102":"Aether"}}'
```
will result in:
```
{"message":"enterprise-id-cannot-be-undefined"} // status code 422
```
and a log message in the ROC:
```
2022-03-01T22:04:36.992Z        WARN    toplevel        server/convert-oapi-gnmi.go:99  EnterpriseId is undefined       {"enterprise": {"enterprise-id":"undefined","site":[{"sim-card":[{"description":"descirption","display-name":"display-name","imsi":456,"sim-id":"sim-id"}],"site-id":"undefined"}]}}
```