### PR TITLE
Publish Docker images to Docker Hub and GHCR

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - docker-publish-oci
     paths:
       - "VERSION"
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,7 +30,8 @@ jobs:
       attestations: write
     uses: onosproject/.github/.github/workflows/release-image.yml@main
     with:
-      docker_tag: ${{ needs.tag-github.outputs.version }}
+      # Prefix the version with 'v' to follow tagging conventions
+      docker_tag: v${{ needs.tag-github.outputs.version }}
     secrets: inherit
 
   update-version:
@@ -39,4 +40,5 @@ jobs:
     uses: onosproject/.github/.github/workflows/bump-version.yml@main
     secrets: inherit
     with:
-      version: ${{ needs.tag-github.outputs.version }}
+      # Prefix the version with 'v' to follow tagging conventions
+      version: v${{ needs.tag-github.outputs.version }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Intel Corporation
+# Copyright 2025 Canonical Ltd.
+name: Release Pipeline
+
+on:
+  push:
+    branches:
+      - main
+      - docker-publish-oci
+    paths:
+      - "VERSION"
+
+permissions:
+  contents: read
+
+jobs:
+  # CAUTION: Other actions depend on this name "tag-github"
+  tag-github:
+    uses: onosproject/.github/.github/workflows/tag-github.yml@main
+    secrets: inherit
+
+  release-image:
+    needs: tag-github
+    if: needs.tag-github.outputs.changed == 'true'
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+      id-token: write
+      attestations: write
+    uses: onosproject/.github/.github/workflows/release-image.yml@main
+    with:
+      docker_tag: ${{ needs.tag-github.outputs.version }}
+    secrets: inherit
+
+  update-version:
+    needs: tag-github
+    if: needs.tag-github.outputs.changed == 'true'
+    uses: onosproject/.github/.github/workflows/bump-version.yml@main
+    secrets: inherit
+    with:
+      version: ${{ needs.tag-github.outputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,14 @@ aether-roc-api-docker: # @HELP build aether-roc-api Docker image
 		-t ${DOCKER_IMAGENAME_API}
 	@rm -rf vendor
 
+# Docker targets for compatibility with GitHub workflow
+docker-build: # @HELP build Docker image
+docker-build: images
+
+docker-push: # @HELP push Docker image
+docker-push:
+	docker push ${DOCKER_IMAGENAME_API}
+
 images: # @HELP build all Docker images
 images: build aether-roc-api-docker
 


### PR DESCRIPTION
Add a GitHub workflow for publishing Docker images to Docker Hub and GHCR when the VERSION is updated.