### PR TITLE
Fix publish pipeline to obey tagging and versioning conventions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,13 +14,16 @@ permissions:
   contents: read
 
 jobs:
-  # CAUTION: Other actions depend on this name "tag-github"
+  # Tag GitHub Release
+  # The convention is to prefix the version with a 'v', e.g., v1.2.3
   tag-github:
     uses: onosproject/.github/.github/workflows/tag-github.yml@main
     with:
       add_v: true
     secrets: inherit
 
+  # Build and Release Docker Image
+  # The convention is to use the same tag for the Docker image as the GitHub Release
   release-image:
     needs: tag-github
     if: needs.tag-github.outputs.changed == 'true'
@@ -35,10 +38,9 @@ jobs:
       docker_tag: ${{ needs.tag-github.outputs.version }}
     secrets: inherit
 
+  # Bump Version
   update-version:
     needs: tag-github
     if: needs.tag-github.outputs.changed == 'true'
     uses: onosproject/.github/.github/workflows/bump-version.yml@main
     secrets: inherit
-    with:
-      version: ${{ needs.tag-github.outputs.version }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,6 +17,8 @@ jobs:
   # CAUTION: Other actions depend on this name "tag-github"
   tag-github:
     uses: onosproject/.github/.github/workflows/tag-github.yml@main
+    with:
+      add_v: true
     secrets: inherit
 
   release-image:
@@ -30,8 +32,7 @@ jobs:
       attestations: write
     uses: onosproject/.github/.github/workflows/release-image.yml@main
     with:
-      # Prefix the version with 'v' to follow tagging conventions
-      docker_tag: v${{ needs.tag-github.outputs.version }}
+      docker_tag: ${{ needs.tag-github.outputs.version }}
     secrets: inherit
 
   update-version:
@@ -40,5 +41,4 @@ jobs:
     uses: onosproject/.github/.github/workflows/bump-version.yml@main
     secrets: inherit
     with:
-      # Prefix the version with 'v' to follow tagging conventions
-      version: v${{ needs.tag-github.outputs.version }}
+      version: ${{ needs.tag-github.outputs.version }}


### PR DESCRIPTION
This PR fixes the publishing pipeline to obey existing tagging and versioning conventions.  Both the release tag and Docker image tag should be prefixed with "v".
