### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ name: Release Pipeline
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - "VERSION"
 


### PR DESCRIPTION
Publish workflow is not triggered because the default branch of the repo is "master" not "main".